### PR TITLE
Fix observable's initial value sent to subscriber

### DIFF
--- a/examples/counter-lib/.size-snapshot.json
+++ b/examples/counter-lib/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.umd.production.js": {
-    "bundled": 35583,
-    "minified": 10575,
-    "gzipped": 3408
+    "bundled": 35588,
+    "minified": 10584,
+    "gzipped": 3412
   },
   "dist/index.umd.development.js": {
-    "bundled": 35707,
-    "minified": 10650,
-    "gzipped": 3425
+    "bundled": 35712,
+    "minified": 10659,
+    "gzipped": 3430
   },
   "dist/index.production.js": {
     "bundled": 3802,

--- a/examples/nav-lib/.size-snapshot.json
+++ b/examples/nav-lib/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.umd.production.js": {
-    "bundled": 35129,
-    "minified": 10311,
-    "gzipped": 3348
+    "bundled": 35134,
+    "minified": 10320,
+    "gzipped": 3353
   },
   "dist/index.umd.development.js": {
-    "bundled": 35253,
-    "minified": 10386,
-    "gzipped": 3364
+    "bundled": 35258,
+    "minified": 10395,
+    "gzipped": 3368
   },
   "dist/index.production.js": {
     "bundled": 3398,

--- a/examples/settings-lib/.size-snapshot.json
+++ b/examples/settings-lib/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.umd.production.js": {
-    "bundled": 35645,
-    "minified": 10519,
-    "gzipped": 3370
+    "bundled": 35650,
+    "minified": 10528,
+    "gzipped": 3374
   },
   "dist/index.umd.development.js": {
-    "bundled": 35769,
-    "minified": 10594,
-    "gzipped": 3387
+    "bundled": 35774,
+    "minified": 10603,
+    "gzipped": 3391
   },
   "dist/index.production.js": {
     "bundled": 3869,

--- a/examples/todo-lib/.size-snapshot.json
+++ b/examples/todo-lib/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.umd.production.js": {
-    "bundled": 44769,
-    "minified": 14172,
-    "gzipped": 4515
+    "bundled": 44774,
+    "minified": 14181,
+    "gzipped": 4520
   },
   "dist/index.umd.development.js": {
-    "bundled": 44893,
-    "minified": 14247,
-    "gzipped": 4536
+    "bundled": 44898,
+    "minified": 14256,
+    "gzipped": 4541
   },
   "dist/index.production.js": {
     "bundled": 6642,

--- a/packages/base/.size-snapshot.json
+++ b/packages/base/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.umd.production.js": {
-    "bundled": 31728,
-    "minified": 8744,
-    "gzipped": 3251
+    "bundled": 31733,
+    "minified": 8753,
+    "gzipped": 3255
   },
   "dist/index.umd.development.js": {
-    "bundled": 31852,
-    "minified": 8819,
-    "gzipped": 3270
+    "bundled": 31857,
+    "minified": 8828,
+    "gzipped": 3274
   },
   "dist/index.production.js": {
     "bundled": 6558,

--- a/packages/core/.size-snapshot.json
+++ b/packages/core/.size-snapshot.json
@@ -1,28 +1,28 @@
 {
   "dist/index.umd.production.js": {
-    "bundled": 27512,
-    "minified": 6585,
-    "gzipped": 2650
+    "bundled": 27517,
+    "minified": 6594,
+    "gzipped": 2654
   },
   "dist/index.umd.development.js": {
-    "bundled": 27512,
-    "minified": 6585,
-    "gzipped": 2650
+    "bundled": 27517,
+    "minified": 6594,
+    "gzipped": 2654
   },
   "dist/index.production.js": {
-    "bundled": 10241,
-    "minified": 4876,
-    "gzipped": 1789
+    "bundled": 10246,
+    "minified": 4885,
+    "gzipped": 1795
   },
   "dist/index.development.js": {
-    "bundled": 10241,
-    "minified": 4876,
-    "gzipped": 1789
+    "bundled": 10246,
+    "minified": 4885,
+    "gzipped": 1795
   },
   "dist/index.es.js": {
-    "bundled": 9792,
-    "minified": 4488,
-    "gzipped": 1694,
+    "bundled": 9797,
+    "minified": 4497,
+    "gzipped": 1699,
     "treeshaked": {
       "rollup": {
         "code": 2205,

--- a/packages/core/src/observable.ts
+++ b/packages/core/src/observable.ts
@@ -45,7 +45,7 @@ export default function createObservable<Value>(
       // is maybe not great for React, because it invokes handler with the
       // same value that things were probably initialized with, but that
       // probably doesn't really effect anything much.
-      observer.next(value);
+      observer.next(this.value);
       return {
         unsubscribe: () => {
           observers = observers.filter(l => l !== observer);

--- a/packages/react/.size-snapshot.json
+++ b/packages/react/.size-snapshot.json
@@ -1,28 +1,28 @@
 {
   "dist/index.umd.production.js": {
-    "bundled": 29949,
-    "minified": 8273,
-    "gzipped": 3084
+    "bundled": 30196,
+    "minified": 8395,
+    "gzipped": 3166
   },
   "dist/index.umd.development.js": {
-    "bundled": 29949,
-    "minified": 8273,
-    "gzipped": 3084
+    "bundled": 30196,
+    "minified": 8395,
+    "gzipped": 3166
   },
   "dist/index.production.js": {
-    "bundled": 7247,
-    "minified": 4163,
-    "gzipped": 1528
+    "bundled": 7480,
+    "minified": 4307,
+    "gzipped": 1620
   },
   "dist/index.development.js": {
-    "bundled": 7247,
-    "minified": 4163,
-    "gzipped": 1528
+    "bundled": 7480,
+    "minified": 4307,
+    "gzipped": 1620
   },
   "dist/index.es.js": {
-    "bundled": 7146,
-    "minified": 4070,
-    "gzipped": 1493,
+    "bundled": 7379,
+    "minified": 4214,
+    "gzipped": 1586,
     "treeshaked": {
       "rollup": {
         "code": 43,


### PR DESCRIPTION
This fixes a mapState observable issue detected when using DevTools to set to a previous state.

The fix is to read the latest values from the feeding observables values when not subscribed to them -- which is already being done for the `value` getter, it just wasn't being used in this case.